### PR TITLE
Feature/adding file list function for reading xml

### DIFF
--- a/opcua_tools/__init__.py
+++ b/opcua_tools/__init__.py
@@ -14,6 +14,6 @@
 
 from .navigation import *
 from .nodeset_generator import create_nodeset2_file, validate_nodeset2_file
-from .nodeset_parser import parse_xml_dir, parse_xml, normalize_wrt_nodeid
+from .nodeset_parser import parse_xml_dir, parse_xml_files, parse_xml, normalize_wrt_nodeid
 from .ua_data_types import *
 from .ua_graph import UAGraph

--- a/opcua_tools/ua_graph.py
+++ b/opcua_tools/ua_graph.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from opcua_tools import UANodeId
 
-from .nodeset_parser import parse_xml_dir
+from .nodeset_parser import parse_xml_dir, parse_xml_files
 from .navigation import resolve_ids_from_browsenames
 from .nodeset_generator import create_nodeset2_file, create_lookup_df, denormalize_nodes_nodeids, \
     denormalize_references_nodeids
@@ -22,6 +22,12 @@ class UAGraph:
 
     def from_path(path: str) -> 'UAGraph':
         parse_dict = parse_xml_dir(path)
+        return UAGraph(nodes=parse_dict['nodes'],
+                       references=parse_dict['references'],
+                       namespaces=parse_dict['namespaces'])
+
+    def from_file_list(file_list: list[str]) -> 'UAGraph':
+        parse_dict = parse_xml_files(file_list)
         return UAGraph(nodes=parse_dict['nodes'],
                        references=parse_dict['references'],
                        namespaces=parse_dict['namespaces'])

--- a/opcua_tools/ua_graph.py
+++ b/opcua_tools/ua_graph.py
@@ -26,7 +26,7 @@ class UAGraph:
                        references=parse_dict['references'],
                        namespaces=parse_dict['namespaces'])
 
-    def from_file_list(file_list: list[str]) -> 'UAGraph':
+    def from_file_list(file_list: List[str]) -> 'UAGraph':
         parse_dict = parse_xml_files(file_list)
         return UAGraph(nodes=parse_dict['nodes'],
                        references=parse_dict['references'],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="0.0.68",
+    version="0.0.69",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,6 +15,7 @@
 import opcua_tools as ot
 import os
 import pandas as pd
+from pathlib import Path
 PATH_HERE = os.path.dirname(__file__)
 
 
@@ -51,3 +52,12 @@ def test_parser_easy_example_stays_put():
             pass
 
 
+def test_parse_file_list():
+    path_to_xmls = str(Path(PATH_HERE) / "testdata" / "parser")
+    xml_list = []
+    for xml in os.listdir(path_to_xmls):
+        full_xml_path = os.path.join(path_to_xmls, xml)
+        if os.path.isfile(full_xml_path):
+            xml_list.append(full_xml_path)
+
+    ot.parse_xml_files(xml_list)


### PR DESCRIPTION
I was missing the option to specify a list of files on which to create the UAGraph object. In my current project I try to read in multiple graph objects for comparison. With the `from_path()` member function using the `parse_xml_dir()` function, I have to create folders for each graph containing duplicate `.xml` files. 

The old function was re-written to take in a list and `parse_xml_dir()` creates a list from a directory and inputs into the new function.