### PR TITLE
Feature/adding enum handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ tests/expected/paper_example/nodes.csv
 
 # Folder for debugging and other
 /scratch
+
+# Ignoring the output from tests
+/tests/output

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 # Ignore the files that are created/changed by pytest
 tests/expected/generator/nodeset2.xml
 tests/expected/paper_example/nodes.csv
+
+# Folder for debugging and other
+/scratch

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,5 @@
+from pathlib import Path
+
+
+def get_project_root() -> Path:
+    return Path(__file__).parent

--- a/opcua_tools/__init__.py
+++ b/opcua_tools/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .navigation import *
+from .nodes_manipulation import transform_ints_to_enums
 from .nodeset_generator import create_nodeset2_file, validate_nodeset2_file
 from .nodeset_parser import (
     parse_xml_dir,

--- a/opcua_tools/nodes_manipulation.py
+++ b/opcua_tools/nodes_manipulation.py
@@ -1,0 +1,183 @@
+# Copyright 2021 Prediktor AS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .ua_graph import UAGraph
+from typing import Tuple
+from .ua_data_types import (
+    UAEnumeration,
+    UAInt32,
+    UAListOf,
+    UnparsedUAExtensionObject,
+    UALocalizedText,
+)
+
+import xmltodict
+import pandas as pd
+import logging
+
+
+logger = logging.getLogger(__name__)
+cl = logging.StreamHandler()
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+cl.setFormatter(formatter)
+logger.addHandler(cl)
+
+
+def get_enum_type_definition(ua_graph: UAGraph, data_type_id: int):
+    """Given a UAGraph object and a internal id of an enum type,
+    the definition of the enumeration will be produced. The form
+    of the definition may vary based on the enumeration.
+
+    Args:
+       ua_graph (UAGraph): UAGraph where the enum defintion is found
+       data_type_id (int): The internal id for data type enum
+
+    Return:
+       The content of the 'Values' column in the node definition
+
+    """
+
+    enum_type_row = ua_graph.nodes[ua_graph.nodes["id"] == data_type_id]
+    enum_type_id = enum_type_row["id"].values[0]
+
+    # The enum type points to the enum definition via HasProperty ReferenceType.
+    # The enum type does not contain the enum definition itself, it points to
+    # an EnumStrings or EnumValues
+    enum_neighbors = ua_graph._get_neighboring_nodes_by_id(enum_type_id, "outgoing")
+    # Ensuring we are getting the HasProperty reference
+    enum_neighbors_has_property = enum_neighbors[
+        enum_neighbors["ReferenceType"] == "HasProperty"
+    ]
+
+    # Getting the node which actually defines the enum
+    enum_definition_id = enum_neighbors_has_property["Trg"].values[0]
+    enum_definition_node = ua_graph.nodes[ua_graph.nodes["id"] == enum_definition_id]
+    enum_ua_list_of = enum_definition_node["Value"].values[0]
+
+    return enum_ua_list_of
+
+
+def create_enum_dict_from_enum_tuples(enum_tuple: Tuple) -> dict[int, str]:
+    """Gets the tuple contents of enums and will attempt to parse the tuple
+    to create and return a dictionary of the enumeration definition.
+
+    Args:
+       enum_tuple (Tuple): Tuple containing enumeration definition
+
+    Return:
+       A dictionary which defines the enumeration
+
+    """
+
+    # The enum definition can be stored in different ways. The two versions observed
+    # is as an unparsed UAExtentionObject in xml or as UALocalizedText.
+    enum_dict = dict()
+    for index, content in enumerate(enum_tuple):
+        if isinstance(content, UnparsedUAExtensionObject):
+            ua_structure = content.body
+            xml_string = ua_structure.xmlstring
+            xml_dict = xmltodict.parse(xml_string)
+
+            value = int(xml_dict["EnumValueType"]["Value"])
+            text = xml_dict["EnumValueType"]["DisplayName"]["Text"]
+            enum_dict[value] = text
+        elif isinstance(content, UALocalizedText):
+            value = index
+            text = content.text
+            enum_dict[value] = text
+        else:
+            raise ValueError(f"The enum content was not supported: {content}")
+
+    if not enum_dict:
+        raise ValueError("The enum dict was not correctly iterated over")
+
+    return enum_dict
+
+
+def instantiate_enum_class(row: pd.DataFrame, ua_graph: UAGraph):
+    """For a single row in the nodes dataframe, which represents an enum value,
+    it will produce an UAEnumeration class based on; the Int provided in the
+    row, the name of the enumeration which is references by the datatype, and
+    the corresponding string value found in the enums definition.
+
+    Args:
+       ua_graph (UAGraph): UAGraph object to transform
+
+    Return:
+       The modified UAGraph with Enumeration classes
+
+    """
+
+    # In some cases the Value is 'None' for some enums and should do
+    # nothing in this case
+    if row["Value"] == None:
+        return None
+
+    # Extracting the actual numeric value as UAInt32 class
+    if isinstance(row["Value"], UAInt32):
+        ua_int = row["Value"].value
+    elif isinstance(row["Value"], UAListOf):
+        ua_int = row["Value"].value[0].value
+    else:
+        raise ValueError(f"row['Value']: {row['Value']} has not been handled properly")
+
+    # Find the enumeration type name for the variable
+    data_type_id = row["DataType"]
+    data_type_name = ua_graph._get_browsename_from_id(data_type_id)
+
+    # Getting the enum type row value
+    enum_ua_list_of = get_enum_type_definition(ua_graph, data_type_id)
+    enum_tuple = enum_ua_list_of.value
+    enum_dict = create_enum_dict_from_enum_tuples(enum_tuple)
+    string = enum_dict[ua_int]
+
+    enum_class = UAEnumeration(value=ua_int, string=string, name=data_type_name)
+
+    return enum_class
+
+
+def transform_ints_to_enums(ua_graph: UAGraph):
+    """Transforms the integer values in the Value column
+    for the Enum data types, to the Enumeration python class. It modifies
+    the input UAGraph directly
+
+    Args:
+       ua_graph (UAGraph): UAGraph object to transform
+
+    """
+
+    # Extracting nodes for readability
+    nodes = ua_graph.nodes.copy()
+
+    # Have to find all children of the Enumeration class
+    enumeration_id = ua_graph.data_type_by_browsename("Enumeration")
+    enumeration_children = ua_graph._get_neighboring_nodes_by_id(
+        enumeration_id, "outgoing"
+    )
+
+    # Extracting UAVariables which datatypes are Enumeration subtypes
+    enum_data_type_ids = enumeration_children["Trg"]
+    enum_nodes = nodes.loc[nodes["DataType"].isin(enum_data_type_ids)]
+    enum_nodes = enum_nodes[enum_nodes["NodeClass"] == "UAVariable"]
+
+    enum_nodes["Value"] = enum_nodes.apply(
+        lambda x: instantiate_enum_class(x, ua_graph), axis=1
+    )
+
+    # Putting the modified nodes back into the nodes dataframe by index
+    nodes.loc[enum_nodes.index, :] = enum_nodes[:]
+
+    ua_graph.nodes = nodes

--- a/opcua_tools/nodeset_generator.py
+++ b/opcua_tools/nodeset_generator.py
@@ -396,6 +396,8 @@ def denormalize_references_nodeids(references, lookup_df):
 
 
 def find_namespaces_in_use(nodes, references, namespace_index):
+    """Find the namespaces which are in use and the BrowseNameNamespaces
+    which are used but already in the list"""
     cs = ["DataType", "ParentNodeId", "MethodDeclarationId"]
     other_nodes = []
     for c in cs:
@@ -431,4 +433,10 @@ def find_namespaces_in_use(nodes, references, namespace_index):
     namespaces_in_use = list(
         nodes.loc[nodes.index.isin(output_nodes.index), "ns"].dropna().unique()
     )
+    # Adding the BrowseNameNamespaces which are not already in the namespace list
+    browsename_namespaces = list(
+        nodes.loc[nodes["ns"] == namespace_index, "BrowseNameNamespace"].unique()
+    )
+    namespaces_in_use = list(set(namespaces_in_use + browsename_namespaces))
+
     return namespaces_in_use

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -429,8 +429,8 @@ def parse_xml_files(
         df_references_list.append((parse_dict["references"]))
         logger.info("Finished parsing " + str(file))
 
-    nodes = pd.concat(df_nodes_list)
-    references = pd.concat(df_references_list)
+    nodes = pd.concat(df_nodes_list, ignore_index=True)
+    references = pd.concat(df_references_list, ignore_index=True)
     lookup_df = normalize_wrt_nodeid(nodes, references)
     return {
         "nodes": nodes,

--- a/opcua_tools/ua_data_types.py
+++ b/opcua_tools/ua_data_types.py
@@ -350,8 +350,9 @@ class UADecimal(UAData):
 
 
 @dataclass(eq=True, frozen=True)
-class UAEnumeration(UAData):
-    pass
+class UAEnumeration(UAInt32):
+    string: str
+    name: str
 
 
 @dataclass(eq=True, frozen=True)

--- a/opcua_tools/ua_graph.py
+++ b/opcua_tools/ua_graph.py
@@ -1,8 +1,10 @@
 import pandas as pd
-from opcua_tools import UANodeId
+from .ua_data_types import UANodeId
 
 from .nodeset_parser import parse_xml_dir, parse_xml_files
 from .navigation import resolve_ids_from_browsenames
+
+import opcua_tools.nodes_manipulation as nodes_manipulation
 from .nodeset_generator import (
     create_nodeset2_file,
     create_lookup_df,
@@ -43,11 +45,15 @@ class UAGraph:
         else:
             parse_dict = parse_xml_dir(path)
 
-        return UAGraph(
+        ua_graph = UAGraph(
             nodes=parse_dict["nodes"],
             references=parse_dict["references"],
             namespaces=parse_dict["namespaces"],
         )
+
+        nodes_manipulation.transform_ints_to_enums(ua_graph)
+
+        return ua_graph
 
     def from_file_list(file_list: List[str]) -> "UAGraph":
         parse_dict = parse_xml_files(file_list)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="0.0.70",
+    version="0.0.72",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/expected/paper_example/nodes.csv
+++ b/tests/expected/paper_example/nodes.csv
@@ -29,6 +29,7 @@ UAVariable,EngineeringUnits,,"UAEngineeringUnits(display_name=UALocalizedText(te
 UAVariable,EngineeringUnits,,"UAEngineeringUnits(display_name=UALocalizedText(text='%', locale='en'), description=UALocalizedText(text='percent', locale='en'), unit_id=20529, namespace_uri='http://www.opcfoundation.org/UA/units/un/cefact')",ns=1;i=38,EngineeringUnits,,,,,,,3,,0,1,,i=887,
 UAVariable,EngineeringUnits,,"UAEngineeringUnits(display_name=UALocalizedText(text='%', locale='en'), description=UALocalizedText(text='percent', locale='en'), unit_id=20529, namespace_uri='http://www.opcfoundation.org/UA/units/un/cefact')",ns=1;i=41,EngineeringUnits,,,,,,,3,,0,1,,i=887,
 UAVariable,EngineeringUnits,,"UAEngineeringUnits(display_name=UALocalizedText(text='%', locale='en'), description=UALocalizedText(text='percent', locale='en'), unit_id=20529, namespace_uri='http://www.opcfoundation.org/UA/units/un/cefact')",ns=1;i=44,EngineeringUnits,,,,,,,3,,0,1,,i=887,
+UAVariable,EnumTest,This is a node to test xml encoding,UAInt32(value=1),ns=1;i=48,NamingRuleEnumTest,,,,,,,,,2,1,,i=120,
 UAVariable,FunctionalAspectName,Lorem ipsum dolor sit amet,UAString(value='E1'),ns=1;i=3,FunctionalAspectName,,,,,,,,,2,1,,,
 UAVariable,FunctionalAspectName,Lorem ipsum dolor sit amet,UAString(value='KA1'),ns=1;i=5,FunctionalAspectName,,,,,,,,,2,1,,,
 UAVariable,FunctionalAspectName,Lorem ipsum dolor sit amet,UAString(value='QNA1'),ns=1;i=7,FunctionalAspectName,,,,,,,,,2,1,,,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -17,6 +17,8 @@ from opcua_tools.nodeset_generator import (
     denormalize_nodes_nodeids,
     denormalize_references_nodeids,
 )
+from definitions import get_project_root
+from opcua_tools import UAGraph
 import os
 import pandas as pd
 
@@ -68,3 +70,17 @@ def test_idempotency():
     pd.testing.assert_frame_equal(references, references2)
 
     os.remove(PATH_HERE + "/expected/generator/nodeset2.xml")
+
+
+def test_ua_graph_write_nodeset_without_crash():
+    path_to_xmls = str(get_project_root() / "tests" / "testdata" / "paper_example")
+    ua_graph = UAGraph.from_path(path_to_xmls)
+
+    output_folder = get_project_root() / "tests" / "output"
+    output_file_path = str(output_folder / "paper_example_output.xml")
+
+    # Creating output folder if it does not exist
+    if not os.path.exists(str(output_folder)):
+        os.makedirs(str(output_folder))
+
+    ua_graph.write_nodeset(output_file_path, "http://prediktor.com/paper_example")

--- a/tests/test_uagraph_enum.py
+++ b/tests/test_uagraph_enum.py
@@ -1,22 +1,39 @@
+import os
+import pytest
 from opcua_tools.nodes_manipulation import transform_ints_to_enums
-from opcua_tools import UAEnumeration
-import opcua_tools as ot
+from opcua_tools import UAGraph, UAEnumeration
 from definitions import get_project_root
 
 
-def test_basic_uagraph_from_path():
+@pytest.fixture(scope="session")
+def ua_graph():
+    path_to_xmls = str(get_project_root() / "tests" / "testdata" / "paper_example")
+    ua_graph = UAGraph.from_path(path_to_xmls)
+    transform_ints_to_enums(ua_graph)
+    return ua_graph
+
+
+def test_basic_ua_graph_from_path(ua_graph):
     """From checking the data previously, we found that there are 251 UAVariables
     which point to enumeration data types. Out of these 84 of then do not contain
     an Int64 value, but 'None' instead. This means the number of UAEnumeration
     classes in the Values column, should be 167 after running the
     transform_ints_to_enums()."""
 
-    path_to_xmls = str(get_project_root() / "tests" / "testdata" / "paper_example")
-    ua_graph = ot.UAGraph.from_path(path_to_xmls)
-    transform_ints_to_enums(ua_graph)
     ua_enumeration_mask = ua_graph.nodes["Value"].apply(
         lambda value: isinstance(value, UAEnumeration)
     )
     ua_enumeration_sum = ua_enumeration_mask.sum()
 
-    assert ua_enumeration_sum == 167
+    assert ua_enumeration_sum == 168
+
+
+def test_enum_ua_graph_xml_encode(ua_graph):
+    output_folder = get_project_root() / "tests" / "output"
+    output_file_path = str(output_folder / "nodeset_enum_output.xml")
+
+    # Creating output folder if it does not exist
+    if not os.path.exists(str(output_folder)):
+        os.makedirs(str(output_folder))
+
+    ua_graph.write_nodeset(output_file_path, "http://prediktor.com/paper_example")

--- a/tests/test_uagraph_enum.py
+++ b/tests/test_uagraph_enum.py
@@ -1,7 +1,8 @@
 import os
 import pytest
 from opcua_tools.nodes_manipulation import transform_ints_to_enums
-from opcua_tools import UAGraph, UAEnumeration
+from opcua_tools.nodeset_parser import parse_xml_files
+from opcua_tools import UAGraph, UAEnumeration, UAInt32
 from definitions import get_project_root
 
 
@@ -29,6 +30,10 @@ def test_basic_ua_graph_from_path(ua_graph):
 
 
 def test_enum_ua_graph_xml_encode(ua_graph):
+    """Test checks that the UAEnumeration is correctly encoded as an Int32
+    when 'xml_encode()' is run. This should occur as the UAEnumeration is an
+    inherited class of UAInt32.
+    """
     output_folder = get_project_root() / "tests" / "output"
     output_file_path = str(output_folder / "nodeset_enum_output.xml")
 
@@ -37,3 +42,14 @@ def test_enum_ua_graph_xml_encode(ua_graph):
         os.makedirs(str(output_folder))
 
     ua_graph.write_nodeset(output_file_path, "http://prediktor.com/paper_example")
+
+    # Reading the file back in, without transforming to enumerations
+    parse_dict = parse_xml_files([output_file_path])
+    nodes = parse_dict["nodes"]
+
+    # Getting nodes which correspond to the enum test node
+    enum_test_node = nodes[nodes["DisplayName"] == "EnumTest"]
+
+    # It should be read correctly read as UAInt32 and thus
+    # the output was writing was to UAInt32
+    assert type(enum_test_node["Value"].values[0]) == UAInt32

--- a/tests/test_uagraph_enum.py
+++ b/tests/test_uagraph_enum.py
@@ -1,0 +1,22 @@
+from opcua_tools.nodes_manipulation import transform_ints_to_enums
+from opcua_tools import UAEnumeration
+import opcua_tools as ot
+from definitions import get_project_root
+
+
+def test_basic_uagraph_from_path():
+    """From checking the data previously, we found that there are 251 UAVariables
+    which point to enumeration data types. Out of these 84 of then do not contain
+    an Int64 value, but 'None' instead. This means the number of UAEnumeration
+    classes in the Values column, should be 167 after running the
+    transform_ints_to_enums()."""
+
+    path_to_xmls = str(get_project_root() / "tests" / "testdata" / "paper_example")
+    ua_graph = ot.UAGraph.from_path(path_to_xmls)
+    transform_ints_to_enums(ua_graph)
+    ua_enumeration_mask = ua_graph.nodes["Value"].apply(
+        lambda value: isinstance(value, UAEnumeration)
+    )
+    ua_enumeration_sum = ua_enumeration_mask.sum()
+
+    assert ua_enumeration_sum == 167

--- a/tests/testdata/paper_example/example.xml
+++ b/tests/testdata/paper_example/example.xml
@@ -16,6 +16,7 @@
         <Description>Lorem ipsum dolor sit amet</Description>
         <References>
             <Reference ReferenceType="ns=0;i=40">ns=2;s=SiteType</Reference>
+            <Reference ReferenceType="ns=0;i=47">ns=1;i=48</Reference>
         </References>
     </UAObject>
     <UAObject NodeId="ns=1;i=2" BrowseName="1:Site1.WaterInjectionSystem">
@@ -519,6 +520,17 @@
         </References>
         <Value>
             <String xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">KA1</String>
+        </Value>
+    </UAVariable>
+    <UAVariable NodeId="ns=1;i=48" BrowseName="2:NamingRuleEnumTest" DataType="i=120">
+        <DisplayName>EnumTest</DisplayName>
+        <Description>This is a node to test xml encoding</Description>
+        <References>
+            <Reference ReferenceType="ns=0;i=40">ns=0;i=68</Reference>
+            <Reference ReferenceType="ns=0;i=37">ns=0;i=78</Reference>
+        </References>
+        <Value>
+            <Int32 xmlns="http://opcfoundation.org/UA/2008/02/Types.xsd">1</Int32>
         </Value>
     </UAVariable>
 </UANodeSet>


### PR DESCRIPTION
I implemented a class which will contain 3 pieces of information for an Enumeration:
 
 - The Integer value of the enumeration
 - The name of the enumeration
 - The string which the enumeration integer corresponds to

After the `nodes`, `references`, and `namespace` were created in the `from_path()` member function of the UAGraph, the enumerations are correctly loaded as UAInt32 classes. The `nodes` table now is manipulated such that those Int32 classes are replaces by a UAEnumeration class. This class is an extension of the UAInt32 class and when written to an .xml file, it will still be correctly encoded as an `Int32`, as it should be in the OPC UA Standard.

In addition to this the following was changed:

- `definitions.py` was added for easier importing and getting file paths
- `find_namespaces_in_use()` function was altered to include `BrowseNameNamespaces` which ended up missing before.
- Fix duplicated indices which occurred after pd.concatination in `nodeset_parser.py`
- Added back the internal `id` of `Src` and `Trg` in `get_neighboring_nodes_by_browsename()`
- Expanded `get_neighboring_nodes_by_browsename()` to include support all node types except UAVariables.
- Created `_get_neighboring_nodes_by_id()` used in function above, also useful for debugging and development
- Created `_get_browsename_from_id()` for ease of use and readability
- Created test to be able to ensure the UAGraph can be written to xml without crashing
- Created tests to check UAEnumerations were correctly created and that it could be properly written to xml_encoded file
- Updated the `paper_example.xml` to include an enumeration variable.