### PR TITLE
Feature/not parse files if not found in namespace dict

### DIFF
--- a/opcua_tools/nodes_manipulation.py
+++ b/opcua_tools/nodes_manipulation.py
@@ -162,6 +162,10 @@ def transform_ints_to_enums(ua_graph: UAGraph):
     # Extracting nodes for readability
     nodes = ua_graph.nodes.copy()
 
+    # Have to first if the are any Enumeration browsenames in nodes dataframe
+    if not (nodes["BrowseName"]=='Enumeration').any():
+        return
+
     # Have to find all children of the Enumeration class
     enumeration_id = ua_graph.data_type_by_browsename("Enumeration")
     enumeration_children = ua_graph._get_neighboring_nodes_by_id(

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -473,7 +473,7 @@ def parse_xml_dir(
     xml_dir: str, namespaces: Optional[List[str]] = None
 ) -> Dict[str, Any]:
     """Parses xml directory and creates Pandas tables which contains
-    consolidated various nodes, references, namespaces, and lookup_df
+    a consolidated nodes, references, namespaces, and lookup_df
     for the files found in the nodes. It will create a list of xml files
     contained in the xml directory. If the 'namespaces' parameter is
     provided, it will not include files with namespaces which are not
@@ -489,16 +489,31 @@ def parse_xml_dir(
     """
 
     files = get_list_of_xml_files(xml_dir)
-
-    if namespaces:
-        files = exclude_files_not_in_namespaces(files, namespaces)
-
     return parse_xml_files(files, namespaces)
 
 
 def parse_xml_files(
     files: List[str], namespaces: Optional[List[str]] = None
 ) -> Dict[str, Any]:
+    """Parses xml list of files and creates Pandas tables which contains
+    a consolidated nodes, references, namespaces, and lookup_df
+    for the files found in the nodes. It will create a list of xml files
+    contained in the xml directory. If the 'namespaces' parameter is
+    provided, it will not include files with namespaces which are not
+    found in the namespace list.
+
+    Args:
+        files (str): Full path of xml files
+        namespaces (Optional[List[str]] = None): Dictionary of namespaces
+
+    Return:
+        Dict[str, Any] of parsed pandas tables from the xml directories.
+
+    """
+
+    if namespaces:
+        files = exclude_files_not_in_namespaces(files, namespaces)
+
     if namespaces is None:
         namespaces = []
     df_nodes_list = []

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -340,6 +340,7 @@ def get_xml_namespaces(xml_file: str) -> List[str]:
     # therefore using the common files name as well.
     if xml_file.endswith("Opc.Ua.NodeSet2.xml"):
         namespace_list.append("http://opcfoundation.org/UA")
+        namespace_list.append("http://opcfoundation.org/UA/")
 
     # Adding tags which contain NamespaceUris
     tag_namespace = ET.iterparse(

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -336,6 +336,10 @@ def get_xml_namespaces(xml_file: str) -> List[str]:
     uaxsd = "{http://opcfoundation.org/UA/2011/03/UANodeSet.xsd}"
 
     namespace_list = []
+    # In some NodeSet2 definition files the <Model> tag is not found
+    # therefore using the common files name as well.
+    if xml_file.endswith("Opc.Ua.NodeSet2.xml"):
+        namespace_list.append("http://opcfoundation.org/UA")
 
     # Adding tags which contain NamespaceUris
     tag_namespace = ET.iterparse(

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -322,6 +322,81 @@ def normalize_wrt_nodeid(nodes: pd.DataFrame, references: pd.DataFrame) -> pd.Da
     return lookup_df
 
 
+def get_xml_namespaces(xml_file: str) -> List[str]:
+    """Opens the xml file provided and peeks inside the file to look for any tags which
+    indicate the namespace uri of the xml file.
+
+    Args:
+        xml_file (str): The full filepath to the xml file to check
+
+    Returns:
+        List[str] containing the different namespace uris which are found in the file.
+
+    """
+    uaxsd = "{http://opcfoundation.org/UA/2011/03/UANodeSet.xsd}"
+
+    namespace_list = []
+    tag_namespace = ET.iterparse(
+        xml_file, events=("start", "end"), tag=[uaxsd + "Uri", uaxsd + "NamespaceUris"]
+    )
+
+    found_nses = False
+    for event, elem in tag_namespace:
+        if not found_nses and event == "end" and elem.tag == uaxsd + "Uri":
+            namespace_list.append(elem.text)
+            elem.clear()
+        elif not found_nses and event == "end" and elem.tag == uaxsd + "NamespaceUris":
+            # All uris in "NamespaceUris" are parsed
+            break
+
+    return namespace_list
+
+
+def get_list_of_xml_files(xml_directory_path: str) -> List[str]:
+    """Returns a list of xml_files in a provided directory
+
+    Args:
+        xml_directory_path (str): Full path to the directory
+
+    Return:
+        List[str] of xmls which are found in the directory
+
+    """
+
+    files = []
+    for file in os.listdir(xml_directory_path):
+        full_path = os.path.join(xml_directory_path, file)
+        if os.path.isfile(full_path) and full_path.endswith(".xml"):
+            files.append(full_path)
+
+    return files
+
+
+def exclude_files_not_in_namespaces(
+    input_files: List[str], namespaces: List[str]
+) -> List[str]:
+    """Removes the files which do not have any NamespaceUris in the namespaces list.
+
+    Args:
+        input_files (List[str]): List of files to filter through.
+        namespaces (List[str]): List of desired namespaces to keep.
+
+    Return:
+        List[str] of xmls which are found in the directory
+
+    """
+    # Removes None for the list if found in the namespaces
+    namespaces_set_list = list(set(filter(None, namespaces)))
+    output_files = input_files.copy()
+    for file in input_files:
+        file_ns_uris = get_xml_namespaces(file)
+        # Removes file if none of the file_ns_uris are in namespaces_set_list
+        if not any(file in file_ns_uris for file in namespaces_set_list):
+            output_files.remove(file)
+
+    return output_files
+
+
 def parse_xml(
     xmlfile: Union[str, BytesIO], namespaces: Optional[List[str]] = None
 ) -> Dict[str, Any]:
@@ -395,13 +470,29 @@ def parse_xml_without_normalization(
 
 
 def parse_xml_dir(
-    xmldir: str, namespaces: Optional[List[str]] = None
+    xml_dir: str, namespaces: Optional[List[str]] = None
 ) -> Dict[str, Any]:
-    files = []
-    for file in os.listdir(xmldir):
-        full_path = os.path.join(xmldir, file)
-        if os.path.isfile(full_path):
-            files.append(full_path)
+    """Parses xml directory and creates Pandas tables which contains
+    consolidated various nodes, references, namespaces, and lookup_df
+    for the files found in the nodes. It will create a list of xml files
+    contained in the xml directory. If the 'namespaces' parameter is
+    provided, it will not include files with namespaces which are not
+    found in the namespace list.
+
+    Args:
+        xml_dir (str): Full path to the directory of xmls
+        namespaces (Optional[List[str]] = None): Dictionary of namespaces
+
+    Return:
+        Dict[str, Any] of parsed pandas tables from the xml directories.
+
+    """
+
+    files = get_list_of_xml_files(xml_dir)
+
+    if namespaces:
+        files = exclude_files_not_in_namespaces(files, namespaces)
+
     return parse_xml_files(files, namespaces)
 
 

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -336,6 +336,8 @@ def get_xml_namespaces(xml_file: str) -> List[str]:
     uaxsd = "{http://opcfoundation.org/UA/2011/03/UANodeSet.xsd}"
 
     namespace_list = []
+
+    # Adding tags which contain NamespaceUris
     tag_namespace = ET.iterparse(
         xml_file, events=("start", "end"), tag=[uaxsd + "Uri", uaxsd + "NamespaceUris"]
     )
@@ -348,6 +350,21 @@ def get_xml_namespaces(xml_file: str) -> List[str]:
         elif not found_nses and event == "end" and elem.tag == uaxsd + "NamespaceUris":
             # All uris in "NamespaceUris" are parsed
             break
+
+    # Adding tags which contain Models and ModelUri
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+
+    found_nses = False
+
+    for models_tag in root.iter(uaxsd + "Models"):
+        for model in models_tag.iter(uaxsd + "Model"):
+            model_uri = model.get("ModelUri")
+            if not found_nses and model_uri:
+                namespace_list.append(model_uri)
+            elif not found_nses and model_uri:
+                # All uris in "NamespaceUris" are parsed
+                break
 
     return namespace_list
 

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -341,6 +341,21 @@ def get_xml_namespaces(xml_file: str) -> List[str]:
     if xml_file.endswith("Opc.Ua.NodeSet2.xml"):
         namespace_list.append("http://opcfoundation.org/UA")
         namespace_list.append("http://opcfoundation.org/UA/")
+        return namespace_list
+
+    # Adding tags which contain Models and ModelUri.
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+
+    found_nses = False
+    root_iter_models = root.iter(uaxsd + "Models")
+    if root_iter_models:
+        for models_tag in root_iter_models:
+            for model in models_tag.iter(uaxsd + "Model"):
+                model_uri = model.get("ModelUri")
+                if not found_nses and model_uri:
+                    namespace_list.append(model_uri)
+        return namespace_list
 
     # Adding tags which contain NamespaceUris
     tag_namespace = ET.iterparse(
@@ -355,21 +370,6 @@ def get_xml_namespaces(xml_file: str) -> List[str]:
         elif not found_nses and event == "end" and elem.tag == uaxsd + "NamespaceUris":
             # All uris in "NamespaceUris" are parsed
             break
-
-    # Adding tags which contain Models and ModelUri
-    tree = ET.parse(xml_file)
-    root = tree.getroot()
-
-    found_nses = False
-
-    for models_tag in root.iter(uaxsd + "Models"):
-        for model in models_tag.iter(uaxsd + "Model"):
-            model_uri = model.get("ModelUri")
-            if not found_nses and model_uri:
-                namespace_list.append(model_uri)
-            elif not found_nses and model_uri:
-                # All uris in "NamespaceUris" are parsed
-                break
 
     return namespace_list
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="0.0.73",
+    version="0.0.74",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -192,16 +192,27 @@ def test_get_list_of_xml_files():
 def test_namespace_dict_parse_xml_dict():
     xml_directory = str(get_project_root() / "tests" / "testdata" / "parser")
     input_namespaces = [
+        "http://opcfoundation.org/UA/",
         "http://www.OPCFoundation.org/UA/2013/01/ISA95",
-        "http://opcfoundation.org/UA/IEC61850-6",
-        "http://opcfoundation.org/UA/IEC61850-7-3",
-        "http://opcfoundation.org/UA/IRC61850-7-4",
+        "http://opcfoundation.org/UA/IEC61850-7-4",
     ]
     expected_files = {
         xml_directory + "/Opc.ISA95.NodeSet2.xml",
-        xml_directory + "/Opc.Ua.IEC61850-6.NodeSet2.xml",
-        xml_directory + "/Opc.Ua.IEC61850-7-3.NodeSet2.xml",
         xml_directory + "/Opc.Ua.IEC61850-7-4.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part10.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part11.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part12.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part13.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part14.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part17.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part19.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part3.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part4.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part5.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part8.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part9.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Services.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.xml",
     }
 
     xml_files = get_list_of_xml_files(xml_directory)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from opcua_tools.nodeset_parser import (
+    exclude_files_not_in_namespaces,
+    get_list_of_xml_files,
+    get_xml_namespaces,
+)
 import opcua_tools as ot
 import os
 import pandas as pd
 from pathlib import Path
+from definitions import get_project_root
 
 PATH_HERE = os.path.dirname(__file__)
 
@@ -128,3 +134,77 @@ def test_parse_scattered_namespace_list():
     assert i_scd_ca_row["ns"].values[0] == 3
     assert oil_and_gas_system_row["ns"].values[0] == 6
     assert site1_row["ns"].values[0] == 8
+
+
+def test_get_xml_namespaces():
+    test_parser_data = get_project_root() / "tests" / "testdata" / "parser"
+
+    files = [
+        str(test_parser_data / "Opc.ISA95.NodeSet2.xml"),
+        str(test_parser_data / "Opc.Ua.IEC61850-6.NodeSet2.xml"),
+        str(test_parser_data / "Opc.Ua.IEC61850-7-4.NodeSet2.xml"),
+    ]
+
+    expected_namespaces = {
+        "http://www.OPCFoundation.org/UA/2013/01/ISA95",
+        "http://opcfoundation.org/UA/IEC61850-7-3",
+        "http://opcfoundation.org/UA/IEC61850-6",
+        "http://opcfoundation.org/UA/IEC61850-7-3",
+        "http://opcfoundation.org/UA/IEC61850-7-4",
+    }
+
+    namespace_set = set()
+    for xml_file in files:
+        namespace_uri_list = get_xml_namespaces(xml_file)
+        namespace_set = namespace_set.union(set(namespace_uri_list))
+
+    assert expected_namespaces == namespace_set
+
+
+def test_get_list_of_xml_files():
+    xml_directory = str(get_project_root() / "tests" / "testdata" / "parser")
+    expected_xml_files = {
+        xml_directory + "/Opc.ISA95.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.IEC61850-6.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.IEC61850-7-3.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.IEC61850-7-4.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part10.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part11.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part12.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part13.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part14.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part17.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part19.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part3.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part4.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part5.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part8.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Part9.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.Services.xml",
+        xml_directory + "/Opc.Ua.NodeSet2.xml",
+    }
+
+    actual_xml_files = get_list_of_xml_files(xml_directory)
+
+    assert expected_xml_files == set(actual_xml_files)
+
+
+def test_namespace_dict_parse_xml_dict():
+    xml_directory = str(get_project_root() / "tests" / "testdata" / "parser")
+    input_namespaces = [
+        "http://www.OPCFoundation.org/UA/2013/01/ISA95",
+        "http://opcfoundation.org/UA/IEC61850-6",
+        "http://opcfoundation.org/UA/IEC61850-7-3",
+        "http://opcfoundation.org/UA/IRC61850-7-4",
+    ]
+    expected_files = {
+        xml_directory + "/Opc.ISA95.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.IEC61850-6.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.IEC61850-7-3.NodeSet2.xml",
+        xml_directory + "/Opc.Ua.IEC61850-7-4.NodeSet2.xml",
+    }
+
+    xml_files = get_list_of_xml_files(xml_directory)
+    xml_files = exclude_files_not_in_namespaces(xml_files, input_namespaces)
+
+    assert expected_files == set(xml_files)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -147,9 +147,7 @@ def test_get_xml_namespaces():
 
     expected_namespaces = {
         "http://www.OPCFoundation.org/UA/2013/01/ISA95",
-        "http://opcfoundation.org/UA/IEC61850-7-3",
         "http://opcfoundation.org/UA/IEC61850-6",
-        "http://opcfoundation.org/UA/IEC61850-7-3",
         "http://opcfoundation.org/UA/IEC61850-7-4",
     }
 


### PR DESCRIPTION
If the `namespaces` argument was passed to `parse_xml_dir()` or `parse_xml_files()` it would set the numeric value of the NodeId as the index in the `namespaces` list for a given namespace.  Previously, if the any of the files had no namespaces found in the namespace list provided, they would still be included in the parsing of the files. Now they are not included if not explictly stated in the `namespaces` list.

The following changes were made:

 - Added `get_xml_namespaces()` function which retrives `NamespaceUris` without parsing entire file
 - Refactored code to function `get_list_of_xml_files()`
 - Added function `exclude_files_not_in_namespaces()` which filters out files not in use
 - Added a bugfix for `transform_ints_to_enums()` by checking if `Enumeration` is in `nodes["BrowseName"]`
 - Added tests for the new and refactored functions