### PR TITLE
More lenient handling of enumerations and strings in enums

### DIFF
--- a/opcua_tools/ua_graph.py
+++ b/opcua_tools/ua_graph.py
@@ -383,7 +383,11 @@ class UAGraph:
         if has_property_name == "EnumStrings":
             ua_list_of = has_property_node["Value"].values[0]
             for localized_text_i, localized_text in enumerate(ua_list_of.value):
-                enum_dict[localized_text_i] = localized_text.text
+                # For case insensitivity captializing first word if string
+                if isinstance(localized_text.text, str):
+                    enum_dict[localized_text_i] = localized_text.text.title()
+                else:
+                    enum_dict[localized_text_i] = localized_text.text
         else:
             raise NotImplementedError("EnumValues not implemented")
 
@@ -402,6 +406,8 @@ class UAGraph:
         # Ad Hoc solution to ensure text in files does not include newlines and line breaks
         string = string.replace("\r", "")
         string = string.replace("\n", "")
+        string = string.title()
+        string = string.strip()
         enum_dict = self.get_enum_dict(enum_name)
         # TODO: Cache enumdict for performance
         # Getting the dict key based on the value

--- a/setup.py
+++ b/setup.py
@@ -20,13 +20,13 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="0.0.75",
+    version="0.0.76",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/PrediktorAS/opcua-tools",
     author="Magnus Bakken",
-    author_email="mba@prediktor.com",
+    author_email="olav.pedersen@prediktor.com",
     license="Apache License 2.0",
     classifiers=[
         "License :: OSI Approved :: Apache License",


### PR DESCRIPTION
In the datawarehouse some of the variables for enumeration nodes are sometimes are incorrectly capitalized compared to the PVTypes library, or might contain leading or trailing whitespaces. These handle these small deviations made in the datawarehouse