### PR TITLE
Chore/dynamic xmlns enum reading

### DIFF
--- a/opcua_tools/nodes_manipulation.py
+++ b/opcua_tools/nodes_manipulation.py
@@ -58,8 +58,14 @@ def create_enum_dict_from_enum_tuples(row: pd.DataFrame) -> Dict[int, str]:
             xml_string = ua_structure.xmlstring
             xml_dict = xmltodict.parse(xml_string)
 
-            value = int(xml_dict["EnumValueType"]["Value"])
-            text = xml_dict["EnumValueType"]["DisplayName"]["Text"]
+            # This notation and searching is to ignore xmlns handling
+            enum_value_dict = [val for key, val in xml_dict.items() if "EnumValueType" in key]
+            value = [val for key, val in enum_value_dict[0].items() if "Value" in key][0]
+            if value.isdigit():
+                value = int(value)
+            enum_value_dict = [val for key, val in xml_dict.items() if "EnumValueType" in key][0]
+            display_name_dict = [val for key, val in enum_value_dict.items() if "DisplayName" in key][0]
+            text = [val for key, val in display_name_dict.items() if "Text" in key][0]
             enum_dict[value] = text
         elif isinstance(content, UALocalizedText):
             value = index

--- a/opcua_tools/ua_graph.py
+++ b/opcua_tools/ua_graph.py
@@ -444,15 +444,15 @@ class UAGraph:
         references which point to the specific node."""
 
         id = None
-        if node_type is "UAObject":
+        if node_type == "UAObject":
             id = self.object_by_browsename(browse_name)
-        elif node_type is "UADataType":
+        elif node_type == "UADataType":
             id = self.data_type_by_browsename(browse_name)
-        elif node_type is "UAReferenceType":
+        elif node_type == "UAReferenceType":
             id = self.reference_type_by_browsename(browse_name)
-        elif node_type is "UAObjectType":
+        elif node_type == "UAObjectType":
             id = self.object_type_by_browsename(browse_name)
-        elif node_type is "UAVariableType":
+        elif node_type == "UAVariableType":
             id = self.variable_type_by_browsename(browse_name)
         else:
             raise ValueError(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="0.0.76",
+    version="0.0.77",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
There was an instance when an xml contained enumeration tags with `xmlns` abbreviations. The enumeration handling could not deal with separating out the prefixes when parsing the xml to a dict. In order to avoid having to pass the `xmlns` or parsing the file to get the namespaces, the dict keys are simply searched through in the dict.