### PR TITLE
Chore/future warning pandas rollback

### DIFF
--- a/opcua_tools/nodes_manipulation.py
+++ b/opcua_tools/nodes_manipulation.py
@@ -212,6 +212,7 @@ def transform_ints_to_enums(ua_graph: UAGraph):
 
     # Have to join the enum_definition_table to enum_nodes table
     enum_def_table = enum_def_table.set_index("id", drop=True)
+    enum_nodes["DataType"] = enum_nodes["DataType"].astype(str).astype(int)
     enum_nodes = enum_nodes.set_index("DataType", drop=False)
     enum_nodes = enum_nodes.join(enum_def_table, how="left")
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "xmltodict>=0.12.0",
         "pytest>=6.2.5",
         "pandas>=1.2.2",
-        "pandas<2.0",
+        "pandas<1.5.0",
         "scipy>=1.6.1",
         "scipy<2.0",
     ],


### PR DESCRIPTION
Due to problems with the new version of pandas `1.5.0` and joining of tables, the package requirement has been rolled back to under that package.

Additionally, a FutureDepricationWarning was omitted, by casting an int column which previously was `dtype=object` to `dtype=int`.