### PR TITLE
Bugfix/fix ua localized text json encoding

### DIFF
--- a/opcua_tools/ua_data_types.py
+++ b/opcua_tools/ua_data_types.py
@@ -629,8 +629,8 @@ class UAQualifiedName(UABuiltIn):
 
 @dataclass(eq=True, frozen=True)
 class UALocalizedText(UABuiltIn):
-    text: str = pd.NA
-    locale: str = pd.NA
+    text: Optional[str] = pd.NA
+    locale: Optional[str] = pd.NA
 
     def __post_init__(self):
         if (not isinstance(self.text, str)) and (not pd.isna(self.text)):
@@ -689,9 +689,9 @@ class UALocalizedText(UABuiltIn):
         json_content = ""
         json_content += '"Text":' + json.dumps(self.text, ensure_ascii=False)
 
-        if input_locale is not None:
+        if not pd.isna(input_locale):
             json_content += ',"Locale":' + json.dumps(input_locale, ensure_ascii=False)
-        elif self.locale is not None:
+        elif not pd.isna(self.locale):
             json_content += ',"Locale":' + json.dumps(self.locale, ensure_ascii=False)
 
         json_content = "{" + json_content + "}"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="1.4.0",
+    version="1.4.1",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_ua_data_types.py
+++ b/tests/test_ua_data_types.py
@@ -621,6 +621,32 @@ def test_ua_localized_text_json_encoding_with_none():
     assert actual_json == expected_json
 
 
+def test_ua_localized_text_json_encoding_with_pd_na():
+    ua_localized_text = UALocalizedText(text=pd.NA, locale=pd.NA)
+    expected_json = None
+    actual_json = ua_localized_text.json_encode()
+    assert actual_json == expected_json
+
+    ua_localized_text = UALocalizedText(text=pd.NA, locale="en-US")
+    expected_json = None
+    actual_json = ua_localized_text.json_encode()
+    assert actual_json == expected_json
+
+
+def test_ua_localized_text_json_encoding_with_input_locale_as_pd_na():
+    ua_localized_text = UALocalizedText(text="Some text", locale=pd.NA)
+    expected_json = '{"Text":"Some text"}'
+    actual_json = ua_localized_text.json_encode(input_locale=pd.NA)
+    assert actual_json == expected_json
+
+
+def test_ua_localized_text_json_encoding_with_locale_as_pd_na():
+    ua_localized_text = UALocalizedText(text="Some text", locale=pd.NA)
+    expected_json = '{"Text":"Some text"}'
+    actual_json = ua_localized_text.json_encode()
+    assert actual_json == expected_json
+
+
 def test_ua_localized_text_json_encode_with_input_locale():
     # Testing that input_locale overrides the locale if there
     ua_localized_text = UALocalizedText(text="foo", locale="en-US")


### PR DESCRIPTION
The changeset consists of:

- fixing invalid behavior of `UALocalizedText` when any of input attributes equal to pd.NA
- adding unit tests that cover the above cases