### PR TITLE
Fix UAString object creation when an empty string is given as an input value

### DIFF
--- a/opcua_tools/ua_data_types.py
+++ b/opcua_tools/ua_data_types.py
@@ -354,9 +354,10 @@ class UAString(UABuiltIn):
     def __post_init__(self):
         if not pd.isna(self.value) and not isinstance(self.value, str):
             raise TypeError("String value must be a string")
-        object.__setattr__(
-            self, "value", str(self.value) if not pd.isna(self.value) else pd.NA
-        )
+        if not (value := str(self.value)) or pd.isna(self.value):
+            object.__setattr__(self, "value", pd.NA)
+        else:
+            object.__setattr__(self, "value", value)
 
     def xml_encode(self, include_xmlns: bool) -> str:
         x = "<String"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="1.4.2",
+    version="1.4.3",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_ua_data_types.py
+++ b/tests/test_ua_data_types.py
@@ -246,6 +246,12 @@ def test_ua_string_creation_with_none_value():
     assert isinstance(ua_string.value, pd._libs.missing.NAType)
 
 
+def test_ua_string_should_be_pd_na_if_empty_one_given():
+    ua_string = UAString("")
+
+    assert isinstance(ua_string.value, pd._libs.missing.NAType)
+
+
 def test_ua_string_xml_encode():
     ua_string = UAString("Hello, World!")
     assert ua_string.xml_encode(include_xmlns=False) == "<String>Hello, World!</String>"


### PR DESCRIPTION
The changeset consists of:

- fixing the case when an UAString object is instantiated using an empty string - it should have the pd.NA as its value, not an empty string
- adding the unit test that covers the above case