### PR TITLE
PENGSOL-733: Move JSON pre-processing behavior to the parsing function

### DIFF
--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -23,6 +23,7 @@ import lxml.etree as ET
 import numpy as np
 import pandas as pd
 
+from opcua_tools.json_parser import parse
 from opcua_tools.json_parser.type_hints import (
     ModelLine,
     ModelsLine,
@@ -190,6 +191,9 @@ def iterparse_xml(
     else:
         json_file_path = xmlfile
 
+    if not os.path.isfile(json_file_path):
+        parse.pre_process_xml_to_json(file_path=xmlfile)
+
     uaxsd = "{http://opcfoundation.org/UA/2011/03/UANodeSet.xsd}"
 
     tags_to_find = list(
@@ -250,6 +254,8 @@ def iterparse_xml(
                     models.append(m)
             else:
                 break
+
+    os.remove(json_file_path)
 
     for event, elem in tagiter:
         if elem.tag == nodeset:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="1.7.5",
+    version="1.7.6",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -21,22 +21,17 @@ from definitions import get_project_root
 
 import opcua_tools as ot
 from opcua_tools import UAGraph
-from opcua_tools.json_parser.parse import pre_process_xml_to_json
 from opcua_tools.nodeset_generator import (
     create_header_xml,
     denormalize_nodes_nodeids,
     denormalize_references_nodeids,
 )
-from opcua_tools.nodeset_parser import get_list_of_xml_files
 
 PATH_HERE = os.path.dirname(__file__)
 
 
 def test_idempotency():
     xml_dir = PATH_HERE + "/testdata/generator"
-    files = get_list_of_xml_files(xml_dir)
-    for f in files:
-        pre_process_xml_to_json(f)
     parse_dict = ot.parse_xml_dir(xml_dir)
     ot.create_nodeset2_file(
         nodes=parse_dict["nodes"].copy(),
@@ -47,9 +42,6 @@ def test_idempotency():
         filename_or_stringio=PATH_HERE + "/expected/generator/nodeset2.xml",
     )
     xml_dir = PATH_HERE + "/expected/generator"
-    files = get_list_of_xml_files(xml_dir)
-    for f in files:
-        pre_process_xml_to_json(f)
 
     parse_dict2 = ot.parse_xml_dir(PATH_HERE + "/expected/generator")
 
@@ -90,10 +82,6 @@ def test_idempotency():
 
 
 def test_ua_graph_write_nodeset_without_crash(paper_example_path):
-    files = get_list_of_xml_files(paper_example_path)
-    for f in files:
-        pre_process_xml_to_json(f)
-
     path_to_xmls = str(paper_example_path)
     ua_graph = UAGraph.from_path(path_to_xmls)
 
@@ -116,8 +104,6 @@ def test_ua_graph_write_nodeset_with_required_models(create_required_models_mock
             Path(PATH_HERE) / "testdata" / "parser" / "Opc.Ua.IEC61850-7-3.NodeSet2.xml"
         ),
     ]
-    for file_path in file_paths:
-        pre_process_xml_to_json(file_path)
 
     ua_graph = UAGraph.from_file_list(file_paths)
 

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -2,8 +2,7 @@ import os.path
 
 from definitions import get_project_root
 
-from opcua_tools import nodeset_parser
-from opcua_tools.json_parser import namespaces, parse
+from opcua_tools.json_parser import namespaces
 
 
 def test_get_namespace_data_should_process_opcua_file_regardless_file_name():
@@ -15,7 +14,6 @@ def test_get_namespace_data_should_process_opcua_file_regardless_file_name():
         "opcua_file_with_different_name",
         "OpcUA_cut.xml",
     )
-    parse.pre_process_xml_to_json(example_xml_path)
 
     example_json_path = f"{example_xml_path}_parsed.json"
 

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -2,7 +2,7 @@ import os.path
 
 from definitions import get_project_root
 
-from opcua_tools.json_parser import namespaces
+from opcua_tools.json_parser import namespaces, parse
 
 
 def test_get_namespace_data_should_process_opcua_file_regardless_file_name():
@@ -16,6 +16,7 @@ def test_get_namespace_data_should_process_opcua_file_regardless_file_name():
     )
 
     example_json_path = f"{example_xml_path}_parsed.json"
+    parse.pre_process_xml_to_json(example_xml_path)
 
     ns_data = namespaces.get_namespace_data_from_file(example_json_path)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,7 +19,6 @@ import pandas as pd
 from definitions import get_project_root
 
 import opcua_tools as ot
-from opcua_tools.json_parser.parse import pre_process_xml_to_json
 from opcua_tools.nodeset_parser import (
     exclude_files_not_in_namespaces,
     get_list_of_xml_files,
@@ -32,8 +31,6 @@ PATH_HERE = os.path.dirname(__file__)
 def test_parsing_without_errors():
     xml_dir = PATH_HERE + "/testdata/parser"
     files = get_list_of_xml_files(xml_dir)
-    for f in files:
-        pre_process_xml_to_json(f)
     ot.parse_xml_dir(xml_dir)
 
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -18,8 +18,6 @@ import pytest
 from definitions import get_project_root
 
 import opcua_tools as ot
-from opcua_tools.json_parser.parse import pre_process_xml_to_json
-from opcua_tools.nodeset_parser import get_list_of_xml_files
 
 PATH_HERE = os.path.dirname(__file__)
 
@@ -31,8 +29,6 @@ def circular_uag():
         1: "http://test.org/Circular/",
     }
     xml_directory = str(get_project_root() / "tests" / "testdata" / "circular")
-    for f in get_list_of_xml_files(xml_directory):
-        pre_process_xml_to_json(f)
     return ot.UAGraph.from_path(xml_directory, namespace_dict)
 
 

--- a/tests/test_ua_graph.py
+++ b/tests/test_ua_graph.py
@@ -19,7 +19,6 @@ import pandas as pd
 import pytest
 
 import opcua_tools as ot
-from opcua_tools.json_parser.parse import pre_process_xml_to_json
 from opcua_tools.ua_data_types import NodeIdType, UANodeId
 
 PATH_HERE = os.path.dirname(__file__)
@@ -125,8 +124,6 @@ def test_ua_graph_should_not_be_instantiated_when_some_target_nodes_are_missing(
         str(Path(PATH_HERE) / "testdata" / "parser" / "Opc.Ua.IEC61850-6.NodeSet2.xml"),
         str(Path(PATH_HERE) / "testdata" / "parser" / "Opc.Ua.NodeSet2.xml"),
     ]
-    for file_path in file_paths:
-        pre_process_xml_to_json(file_path)
 
     with pytest.raises(ValueError) as e:
         ot.UAGraph.from_file_list(file_paths)
@@ -142,8 +139,6 @@ def test_ua_graph_should_not_be_instantiated_when_some_source_nodes_are_missing(
         str(Path(PATH_HERE) / "testdata" / "paper_example" / "rds_og_fragment.xml"),
         str(Path(PATH_HERE) / "testdata" / "paper_example" / "iec63131_fragment.xml"),
     ]
-    for file_path in file_paths:
-        pre_process_xml_to_json(file_path)
 
     with pytest.raises(ValueError) as e:
         ot.UAGraph.from_file_list(file_paths)
@@ -165,8 +160,6 @@ def test_ua_graph_with_nested_nodeid_value():
             / "nested_nodeid.xml"
         ),
     ]
-    for file_path in file_paths:
-        pre_process_xml_to_json(file_path)
 
     graph = ot.UAGraph.from_file_list(file_paths)
 

--- a/tests/test_uagraph_enum.py
+++ b/tests/test_uagraph_enum.py
@@ -4,16 +4,13 @@ import pytest
 from definitions import get_project_root
 
 from opcua_tools import UAEnumeration, UAGraph, UAInt32
-from opcua_tools.json_parser.parse import pre_process_xml_to_json
 from opcua_tools.nodes_manipulation import transform_ints_to_enums
-from opcua_tools.nodeset_parser import get_list_of_xml_files, parse_xml_files
+from opcua_tools.nodeset_parser import parse_xml_files
 
 
 @pytest.fixture(scope="session")
 def ua_graph(paper_example_path):
     path_to_xmls = str(paper_example_path)
-    for f in get_list_of_xml_files(path_to_xmls):
-        pre_process_xml_to_json(f)
     ua_graph = UAGraph.from_path(path_to_xmls)
     transform_ints_to_enums(ua_graph)
     return ua_graph
@@ -48,8 +45,6 @@ def test_enum_ua_graph_xml_encode(ua_graph):
         os.makedirs(str(output_folder))
 
     ua_graph.write_nodeset(output_file_path, "http://prediktor.com/paper_example")
-
-    pre_process_xml_to_json(output_file_path)
 
     # Reading the file back in, without transforming to enumerations
     parse_dict = parse_xml_files([output_file_path])

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -5,8 +5,6 @@ import pandas as pd
 import pytest
 from definitions import get_project_root
 
-from opcua_tools.json_parser.parse import pre_process_xml_to_json
-from opcua_tools.nodeset_parser import get_list_of_xml_files
 from opcua_tools.ua_data_types import UABoolean, UAInt32
 from opcua_tools.ua_graph import UAGraph
 from opcua_tools.validator import exceptions, value_validator
@@ -20,8 +18,6 @@ class TestValidatorFeature:
         self, _, invalid_files_root_path
     ):
         path_to_xmls = str(invalid_files_root_path / "missing_data_types")
-        for f in get_list_of_xml_files(path_to_xmls):
-            pre_process_xml_to_json(f)
         ua_graph = UAGraph.from_path(path_to_xmls)
 
         output_folder = get_project_root() / "tests" / "output"
@@ -45,8 +41,6 @@ class TestValidatorFeature:
         self, _, invalid_files_root_path
     ):
         path_to_xmls = str(invalid_files_root_path / "non_matching_datatype")
-        for f in get_list_of_xml_files(path_to_xmls):
-            pre_process_xml_to_json(f)
         ua_graph = UAGraph.from_path(path_to_xmls)
 
         output_folder = get_project_root() / "tests" / "output"


### PR DESCRIPTION
Invoking `parse.pre_process_xml_to_json()` for each file before creating `UAGraph` is redundant and leaves artifacts in the form of the `..._parsed.json` files. It will be much more convenient for a user to hide the behavior in the `iterparse_xml()` function and remove the JSON files once there are not needed.