### PR TITLE
PENGSOL-764: Fix UAGraph creation when a nodeset2 file with no nodes defined is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,76 @@ OPC UA information models are represented and manipulated in Pandas Dataframes.
 There is a parser from NodeSet2 XML files, functions for manipulating/extracting information from information models and a NodeSet2 generator.
 There are some general tests here, but most of the testing is indirect through its use in [quarry](https://github.com/PrediktorAS/quarry) and other internal tools.
 ## Installation
-To install, run this command:
+To install the newest version, run this command:
 ```
-pip install git+https://github.com/PrediktorAS/opcua-tools.git
+pip install opcua-tools
 ```
 ## Usage
-Forthcoming... see the test cases.
+```python
+from opcua_tools.ua_graph import UAGraph
+
+graph = UAGraph.from_path("root/path/to/nodeset2/files")
+# or
+file_paths = ["path/to/nodeset2/file1.xml", "path/to/nodeset2/file2.xml"]
+graph = UAGraph.from_file_list(file_paths)
+```
+
+This approach will also work:
+```python
+import opcua_tools as ot
+
+graph = ot.UAGraph.from_path("root/path/to/nodeset2/files")
+```
+
+The `UAGraph` object is responsible to store information about the OPC UA information model.
+You will find all the nodes and references in a form of pandas'DataFrames (`graph.nodes`
+and `graph.references`).
+
+## Development
+
+### Requirements
+The current version of library was mostly developed and tested with Python 3.12.
+Create a virtual environment and install the requirements:
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+in Windows:
+```bash
+python -m venv venv
+venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+The repo has some pre-commit hooks introduced. Remember to install them:
+```bash
+pre-commit install
+```
+
+### Running tests
+To run the tests, you need to have `pytest` installed. You can install it using pip:
+```bash
+pip install pytest
+```
+Then, you can run the tests using the following command:
+```bash
+pytest tests/
+```
+
+### Releasing a new version
+1. Create a Pull Request from your feature branch to main with the changes you
+    want to release. Remember to update the version in `setup.py` file.
+2. Merge the Pull Request.
+3. Go to the "Releases" section of the repository - [here](https://github.com/PrediktorAS/opcua-tools/releases).
+4. Click on "Draft a new release".
+5. Click on the "Choose a tag" button and type the new version number - the one that corresponds with the one
+    you wrote in the `setup.py` file, eg. (`v1.1.1`).
+6. Click on the "Generate release notes" button. Alternatively, you can write a title and 
+    description for the release.
+7. Click on the "Publish release" button.
+8. An automatic action will be triggered. The new version of the package should be available soon.
+    You can find it on [PyPI](https://pypi.org/project/opcua-tools/#history).
 
 ## Logging
 
@@ -34,4 +98,4 @@ The code in this repository is copyrighted to [TGS Prediktor AS](https://predikt
 Exceptions apply to some of the test data and static files for parsing/generation (see document headers for license information).
 
 Authors:
-Magnus Bakken, Hans Petter Ladim, Olav Landmark Pedersen, [Dawid Makar](mailto:dawid.makar@tgs.com), Mikaeil Orfanian
+Magnus Bakken, Hans Petter Ladim, Olav Landmark Pedersen, Dawid Makar, Mikaeil Orfanian

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -22,7 +22,6 @@ from typing import Any, Dict, List, Optional, Union
 import lxml.etree as ET
 import numpy as np
 import pandas as pd
-from validator import exceptions
 
 from opcua_tools.json_parser import parse
 from opcua_tools.json_parser.type_hints import (
@@ -32,6 +31,7 @@ from opcua_tools.json_parser.type_hints import (
     UANodeSetLine,
 )
 from opcua_tools.ua_data_types import UANodeId
+from opcua_tools.validator import exceptions
 from opcua_tools.value_parser import parse_nodeid, parse_value
 
 logger = logging.getLogger(__name__)

--- a/opcua_tools/nodeset_parser.py
+++ b/opcua_tools/nodeset_parser.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Union
 import lxml.etree as ET
 import numpy as np
 import pandas as pd
+from validator import exceptions
 
 from opcua_tools.json_parser import parse
 from opcua_tools.json_parser.type_hints import (
@@ -298,6 +299,14 @@ def iterparse_xml(
         # Release memory
         list(map(lambda x: x.clear(), elems))
         df_list.append(df)
+
+    if not df_list:
+        namespace_uri_to_remove = models[0].get("uri")
+        namespace_uri_index_in_namespaces_map = desired_namespace_list.index(
+            namespace_uri_to_remove
+        )
+        desired_namespace_list.pop(namespace_uri_index_in_namespaces_map)
+        raise exceptions.ValidationError(f"No nodes found in the XML file: {xmlfile}")
 
     nodes = pd.concat(df_list)
 
@@ -731,7 +740,13 @@ def parse_xml_files(
             )
 
         logger.info("Started parsing " + str(file))
-        parse_dict = parse_xml_without_normalization(file, namespaces)
+
+        try:
+            parse_dict = parse_xml_without_normalization(file, namespaces)
+        except exceptions.ValidationError:
+            logger.warning(f"{file} has no nodes. Skipping...")
+            continue
+
         namespaces = parse_dict["namespaces"]
         df_nodes_list.append(parse_dict["nodes"])
         df_references_list.append((parse_dict["references"]))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="opcua-tools",
-    version="1.8.1",
+    version="1.8.2",
     description="OPCUA Tools for Python using Pandas DataFrames",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_ua_graph.py
+++ b/tests/test_ua_graph.py
@@ -168,3 +168,31 @@ def test_ua_graph_with_nested_nodeid_value():
     assert requested_variable_value == UANodeId(
         namespace=0, nodeid_type=NodeIdType.NUMERIC, value="0"
     )
+
+
+def test_ua_graph_can_be_created_with_nodeset2_file_without_nodes():
+    file_paths = [
+        str(Path(PATH_HERE) / "testdata" / "parser" / "Opc.Ua.NodeSet2.xml"),
+        str(
+            Path(PATH_HERE)
+            / "testdata"
+            / "invalid_example"
+            / "empty_nodeset2_file"
+            / "nodeset2_file_with_no_nodes.xml"
+        ),
+        str(
+            Path(PATH_HERE)
+            / "testdata"
+            / "invalid_example"
+            / "empty_nodeset2_file"
+            / "nodeset2_file_with_no_nodes_2.xml"
+        ),
+        str(Path(PATH_HERE) / "testdata" / "paper_example" / "rds_og_fragment.xml"),
+    ]
+
+    graph = ot.UAGraph.from_file_list(file_paths)
+
+    assert graph.namespaces == [
+        "http://opcfoundation.org/UA/",
+        "http://prediktor.com/RDS-OG-Fragment",
+    ]

--- a/tests/testdata/invalid_example/empty_nodeset2_file/nodeset2_file_with_no_nodes.xml
+++ b/tests/testdata/invalid_example/empty_nodeset2_file/nodeset2_file_with_no_nodes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+    <NamespaceUris>
+        <Uri>http://example.com/paper_example</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://example.com/paper_example" PublicationDate="2020-04-06T08:03:52Z" Version="1.0.0">
+        </Model>
+    </Models>
+    <Aliases>
+    </Aliases>
+</UANodeSet>

--- a/tests/testdata/invalid_example/empty_nodeset2_file/nodeset2_file_with_no_nodes_2.xml
+++ b/tests/testdata/invalid_example/empty_nodeset2_file/nodeset2_file_with_no_nodes_2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+    <NamespaceUris>
+        <Uri>http://example.com/paper_example_2</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://example.com/paper_example_2" PublicationDate="2020-04-06T08:03:52Z" Version="1.0.0">
+        </Model>
+    </Models>
+    <Aliases>
+    </Aliases>
+</UANodeSet>


### PR DESCRIPTION
Some of the sites are built with tens of input XML model files. Some of them may have just metadata about the model, but no nodes specified. If any of these files are provided to the latest version released, the UAGraph creation fails with an exception that does not give too much context. The file is a proper nodeset2 file, so the UAGraph creation should pass in this scenario. The changes include:
- logging a warning specifying which file has no nodes
- removing the related namespace from the list
- proceeding to the next file